### PR TITLE
Add generic type

### DIFF
--- a/src/utils/flowRight.ts
+++ b/src/utils/flowRight.ts
@@ -1,4 +1,8 @@
-export function compose(...funcs: Function[]) {
+interface ComponentEnhancer<TInner, TOuter> {
+  (component: Component<TInner>): ComponentClass<TOuter>;
+}
+
+export function compose<TInner, TOuter>(...funcs: Function[]): ComponentEnhancer<TInner, TOuter> {
   const functions = funcs.reverse();
   return function (...args: any[]) {
     const [firstFunction, ...restFunctions] = functions

--- a/src/utils/flowRight.ts
+++ b/src/utils/flowRight.ts
@@ -1,3 +1,5 @@
+import { ComponentType as Component, ComponentClass } from 'react';
+
 interface ComponentEnhancer<TInner, TOuter> {
   (component: Component<TInner>): ComponentClass<TOuter>;
 }


### PR DESCRIPTION
How would you feel about adding generic typing to be able to have prop type checking of a component that was enhanced with this `compose` function? At the moment all type checking is lost when a component is wrapped in `compose`.

I noticed this when replacing recompose/compose by react-apollo/compose. This is based off https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3ba6ab5908979830a8bc179cccd428180a5e0ff2/types/recompose/index.d.ts#L302

If you would like me to modify it in any way, let me know.

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

